### PR TITLE
Install zlib as Python3.9 fails without it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazonlinux
 
 RUN yum update -y
-RUN yum install gcc openssl-devel bzip2-devel libffi-devel wget tar gzip zip make -y
+RUN yum install gcc openssl-devel bzip2-devel libffi-devel wget tar gzip zip make zlib-devel -y
 
 # Install Python 3.9
 WORKDIR /


### PR DESCRIPTION
Resolves "ModuleNotFoundError: No module named 'zlib'"
zipimport.ZipImportError: can't decompress data; zlib not available

*Issue #, if available:*
RUN make altinstall fails with above message

*Description of changes:*
Install zlib-devel package to allow zip to function


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
